### PR TITLE
Update rmatrixnorm() in distributions.R

### DIFF
--- a/R/distributions.R
+++ b/R/distributions.R
@@ -1200,7 +1200,7 @@ rmatrixnorm <- function(M, U, V)
      n <- nrow(U)
      k <- ncol(V)
      Z <- matrix(rnorm(n * k), n, k)
-     X <- M + t(chol(U)) %*% Z %*% chol(V)
+     X <- M + chol(U) %*% Z %*% chol(V)
      return(X)
      }
 


### PR DESCRIPTION
Thank you. In addition, as referenced in issue #15, the `rmatrixnorm()` function uses the upper-triangular matrix of chol(U) instead of the lower-triangular matrix.  This pull request fixes this line in `rmatrixnorm()` function: 

` X <- M + t(chol(U)) %*% Z %*% chol(V)`
to
` X <- M + chol(U) %*% Z %*% chol(V)`